### PR TITLE
Add space between quote and cited reference. Fixes #6

### DIFF
--- a/blockquotes.js
+++ b/blockquotes.js
@@ -57,6 +57,7 @@
 	  						if ( e.data.quote ) {
 	  							blockquote += '<blockquote>';
 	  							blockquote += e.data.quote;
+	  							blockquote += ' ';
 	  							blockquote += cite;
 	  							blockquote += '</blockquote>';
 						    }


### PR DESCRIPTION
I noticed the same thing as SDavisMedia... the end of the quote and the start of the citation was missing a single space. Seemed like a pretty safe assumption that you'd want the space in there for readability, so I went ahead and added it.
