### PR TITLE
Added filters for more customizable blockquote template

### DIFF
--- a/better-blockquotes.php
+++ b/better-blockquotes.php
@@ -79,7 +79,13 @@ class BetterBlockquotes {
 			'citation'  => __( 'Citation', 'better-blockquotes' ),
 			'citation_link'  => __( 'Citation Link', 'better-blockquotes' ),
 			'class' => __( 'Class', 'better-blockquotes' ),
-			'class_options' => apply_filters( 'betterblockquotes_classes', false )
+			'class_options' => apply_filters( 'betterblockquotes_classes', false ),
+			'html_filters' => array(
+				'before_blockquote' => apply_filters( 'betterblockquotes_before_blockquote', '' ),
+				'after_blockquote' => apply_filters( 'betterblockquotes_after_blockquote', '' ),
+				'before_cite' => apply_filters( 'betterblockquotes_before_cite', '' ),
+				'after_cite' => apply_filters( 'betterblockquotes_after_cite', '' )
+			)
 		) );
 
 	}

--- a/blockquotes.js
+++ b/blockquotes.js
@@ -62,13 +62,14 @@
 					    title: better_blockquotes.blockquote,
 					    body: body,
 					    onsubmit: function( e ) {
-						    var blockquote = '';
-						    var cite = '';
+						    var htmlFilters = better_blockquotes.html_filters;
+						    var blockquote = htmlFilters.before_blockquote;
+						    var cite = htmlFilters.before_cite;
 
 							if ( e.data.link && e.data.cite ) {
-								cite = '<cite><a href="' + e.data.link + '">' + e.data.cite + '</a></cite>';
+								cite += '<cite><a href="' + e.data.link + '">' + e.data.cite + '</a></cite>';
 	              			} else if ( !e.data.link && e.data.cite ) {
-				  				cite = '<cite>' + e.data.cite + '</cite>';
+				  				cite += '<cite>' + e.data.cite + '</cite>';
 	              			}
 
 	  						if ( e.data.quote ) {
@@ -78,8 +79,8 @@
 			  						blockquote += '<blockquote>';
 		  						}
 	  							blockquote += e.data.quote;
-	  							blockquote += cite;
-	  							blockquote += '</blockquote>';
+	  							blockquote += cite + htmlFilters.after_cite;
+	  							blockquote += '</blockquote>' + htmlFilters.after_blockquote;
 						    }
 
 					        editor.insertContent(blockquote);


### PR DESCRIPTION
I added 4 filters for more customizable output: betterblockquotes_before_blockquote,  betterblockquotes_before_cite, betterblockquotes_after_cite and betterblockquotes_after_blockquote.
```
<!-- betterblockquotes_before_blockquote -->
<blockquote>
This is the quote.
<!-- betterblockquotes_before_cite -->
<cite><a href="#">Citation</a></cite>
<!-- betterblockquotes_after_cite -->
</blockquote>
<!-- betterblockquotes_after_blockquote -->
```

One can use them to wrap html elements inside and around blockquote or add some text, like "Author: " before `cite`.